### PR TITLE
Rewrite tiny doublesha256

### DIFF
--- a/src/ecc/address.rs
+++ b/src/ecc/address.rs
@@ -236,9 +236,7 @@ impl Address {
 
     /// Double SHA-256 hash for legacy addresses
     fn double_sha256(data: &[u8]) -> [u8; 32] {
-        let first_hash = Sha256::digest(data);
-        let second_hash = Sha256::digest(&first_hash);
-        second_hash.into()
+        Sha256::digest( Sha256::digest(data) ).into()
     }
 }
 
@@ -418,5 +416,19 @@ mod tests {
         assert!(Address::from_string("invalid_address").is_err());
         assert!(Address::from_string("RSQ123invalid").is_err());
         assert!(!Address::validate_string("not_an_address"));
+    }
+
+    #[test]
+    fn test_calculate_double_sha() {
+        fn hash_to_str(data: &[u8; 32]) -> String {
+            use std::fmt::Write;
+            let mut ret = String::with_capacity(32*2);
+            for &by in data {
+                write!(&mut ret, "{:02x}", by).unwrap();
+            }
+            return ret;
+        }
+        let s = Address::double_sha256(b"abc");
+        assert_eq!(hash_to_str(&s) , "4f8b42c22dd3729b519ba6f68d2da7cc5b2d606d05daed5ad5128cc03e6c6358");
     }
 }

--- a/tests/compatibility/ecc_compatibility.rs
+++ b/tests/compatibility/ecc_compatibility.rs
@@ -284,6 +284,8 @@ fn test_address_validation_compatibility() {
         "RSQLoVGDgRs9hTfTNJNuXKSpywcbdvy1agVX", // Wrong checksum
         "BTSLoVGDgRs9hTfTNJNuXKSpywcbdvy1agVK", // Wrong prefix
         "RSQLoVGDgRs9hTfTNJNuXKSpywcbdvy1agV", // Too short
+        "RSQLoVGDgRs9hTfTNJNuXKSpywcbdvy1agVKa", // extra char at end
+        "",                                      // empty
     ];
     
     for address_str in &invalid_addresses {


### PR DESCRIPTION
## Summary by Sourcery

Simplify the double SHA-256 implementation and improve test coverage for address hashing and validation.

Enhancements:
- Nest Sha256::digest calls in double_sha256 to inline the hashing steps

Tests:
- Add a unit test verifying the double SHA-256 hash of "abc" matches the expected value
- Include extra invalid address cases (an extra character and empty string) in compatibility tests